### PR TITLE
Support for Scylla 4.4 new generation tables format

### DIFF
--- a/topology.go
+++ b/topology.go
@@ -175,10 +175,8 @@ func (gf *generationFetcher) tryFetchGenerations() {
 	}
 
 	consistency := gocql.One
-	if size == 2 {
+	if size >= 2 {
 		consistency = gocql.Quorum
-	} else if size >= 3 {
-		consistency = gocql.All
 	}
 
 	// Try switching to a new format before fetching any generations

--- a/topology.go
+++ b/topology.go
@@ -291,8 +291,3 @@ func (gs *generationSourcePre4_4) getGenerationTimes(consistency gocql.Consisten
 func (gs *generationSourcePre4_4) maybeUpgrade() (generationSource, error) {
 	return gs, nil
 }
-
-// Finds a name of a supported table for fetching cdc streams
-func getGenerationsTableName(session *gocql.Session) (string, error) {
-	return "system_distributed.cdc_streams_descriptions", nil
-}

--- a/topology.go
+++ b/topology.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -12,7 +13,8 @@ import (
 )
 
 var (
-	ErrNoGenerationsPresent = errors.New("there are no generations present")
+	ErrNoGenerationsPresent               = errors.New("there are no generations present")
+	ErrNoSupportedGenerationTablesPresent = errors.New("no supported generation tables are present")
 )
 
 const (
@@ -73,6 +75,11 @@ func newGenerationFetcher(
 	startFrom time.Time,
 	logger Logger,
 ) (*generationFetcher, error) {
+	source, err := chooseGenerationSource(session, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect version of the generation tables used by the cluster: %v", err)
+	}
+
 	gf := &generationFetcher{
 		session:  session,
 		lastTime: startFrom,
@@ -82,12 +89,45 @@ func newGenerationFetcher(
 		stopCh:       make(chan struct{}),
 		refreshCh:    make(chan struct{}, 1),
 
-		source: &generationSourcePre4_4{
-			session: session,
-			logger:  logger,
-		},
+		source: source,
 	}
 	return gf, nil
+}
+
+func chooseGenerationSource(session *gocql.Session, logger Logger) (generationSource, error) {
+	hasPre4_4, err := isTableInSchema(session, generationsTableNamePre4_4)
+	if err != nil {
+		return nil, err
+	}
+	hasPost4_4, err := isTableInSchema(session, streamsTableSince4_4)
+	if err != nil {
+		return nil, err
+	}
+
+	if !hasPost4_4 && !hasPre4_4 {
+		// There are no tables we know how to use - return an error
+		return nil, ErrNoSupportedGenerationTablesPresent
+	}
+
+	if hasPost4_4 && !hasPre4_4 {
+		// There is only 4.4+ table, we can immediately start
+		// using the new table
+		return &generationSourceSince4_4{
+			session: session,
+			logger:  logger,
+		}, nil
+	}
+
+	// If we are here, then the pre-4.4 table is there for sure
+	// If there is no 4.4+ table - we will start using it right away
+	// If there is a 4.4+ table - the maybeUpgrade function
+	// will take care of switching to the new table, but only after
+	// generation rewriting completes
+
+	return &generationSourcePre4_4{
+		session: session,
+		logger:  logger,
+	}, nil
 }
 
 func (gf *generationFetcher) Run(ctx context.Context) error {


### PR DESCRIPTION
Upcoming Scylla 4.4 version introduces new user-facing tables which contain information about generations: `cdc_generation_timestamps` and `cdc_streams_descriptions_v2`. The old table `cdc_streams_descriptions` stops being updated after a cluster is fully upgraded to 4.4 or newer. This means that the library, which is was unaware of the new tables, will stop consuming changes if a new generation appears in a fully upgraded cluster.

This PR introduces support for the new user-facing tables. Now, the library will work correctly with both pre-4.4 and 4.4+ clusters. Moreover, it will automatically switch from old to new tables after the cluster is upgraded to 4.4+.

I tested this change using the same procedure as described in the corresponding [PR description](https://github.com/scylladb/scylla-cdc-java/pull/21#issue-582172744) in scylla-cdc-java, with following changes:

- I used Scylla 4.3.0 and a recent Scylla master with a change which introduced a 2-minute delay before generations were rewritten ([link](https://github.com/piodul/scylla/tree/wait-120s-before-rewriting) to the branch),
- I used scylla-cdc-go's printer example instead of scylla-cdc-java's.