### PR TITLE
Improves/Fixes TableBackedProgressManager

### DIFF
--- a/change.go
+++ b/change.go
@@ -456,6 +456,14 @@ type ChangeConsumer interface {
 	// If this method returns an error, the library will stop with an error.
 	Consume(ctx context.Context, change Change) error
 
+	// Invoked upon empty results from the CDC log associated with the stream of
+	// the ChangeConsumer. This method is called to acknowledge a query window
+	// has been executed against the stream and the CDC log is to be considered
+	// completed as of 'ackTime' param passed.
+	//
+	// If this method returns an error, the library will stop with an error.
+	Empty(ctx context.Context, ackTime gocql.UUID) error
+
 	// Called after all rows from the stream were consumed, and the reader
 	// is about to switch to a new generation, or stop execution altogether.
 	//
@@ -493,6 +501,10 @@ func (ccfif *changeConsumerFuncInstanceFactory) CreateChangeConsumer(
 type changeConsumerFuncInstance struct {
 	tableName string
 	f         ChangeConsumerFunc
+}
+
+func (ccfi *changeConsumerFuncInstance) Empty(ctx context.Context, newTime gocql.UUID) error {
+	return nil
 }
 
 func (ccfi *changeConsumerFuncInstance) End() error {

--- a/examples/replicator/main.go
+++ b/examples/replicator/main.go
@@ -51,12 +51,11 @@ func main() {
 	clWrite := parseConsistency(writeConsistency)
 
 	adv := scyllacdc.AdvancedReaderConfig{
-		ConfidenceWindowSize:   30 * time.Second,
-		ChangeAgeLimit:         10 * time.Minute,
-		QueryTimeWindowSize:    60 * time.Second,
-		PostEmptyQueryDelay:    30 * time.Second,
-		PostNonEmptyQueryDelay: 10 * time.Second,
-		PostFailedQueryDelay:   1 * time.Second,
+		ConfidenceWindowSize: 30 * time.Second,
+		ChangeAgeLimit:       10 * time.Minute,
+		QueryTimeWindowSize:  60 * time.Second,
+		PostQueryDelay:       10 * time.Second,
+		PostFailedQueryDelay: 1 * time.Second,
 	}
 
 	fmt.Println("Parameters:")
@@ -71,8 +70,7 @@ func main() {
 	fmt.Printf("  Confidence window size: %s\n", adv.ConfidenceWindowSize)
 	fmt.Printf("  Change age limit: %s\n", adv.ChangeAgeLimit)
 	fmt.Printf("  Query window size: %s\n", adv.QueryTimeWindowSize)
-	fmt.Printf("  Delay after poll with empty results: %s\n", adv.PostEmptyQueryDelay)
-	fmt.Printf("  Delay after poll with non-empty results: %s\n", adv.PostNonEmptyQueryDelay)
+	fmt.Printf("  Delay after poll with non-empty results: %s\n", adv.PostQueryDelay)
 	fmt.Printf("  Delay after failed poll: %s\n", adv.PostFailedQueryDelay)
 
 	var fullyQualifiedTables []string

--- a/examples/replicator/replicator_test.go
+++ b/examples/replicator/replicator_test.go
@@ -375,12 +375,11 @@ func TestReplicator(t *testing.T) {
 	t.Log("running replicators")
 
 	adv := scyllacdc.AdvancedReaderConfig{
-		ChangeAgeLimit:         time.Minute,
-		PostNonEmptyQueryDelay: 3 * time.Second,
-		PostEmptyQueryDelay:    3 * time.Second,
-		PostFailedQueryDelay:   3 * time.Second,
-		QueryTimeWindowSize:    5 * time.Minute,
-		ConfidenceWindowSize:   time.Millisecond,
+		ChangeAgeLimit:       time.Minute,
+		PostQueryDelay:       3 * time.Second,
+		PostFailedQueryDelay: 3 * time.Second,
+		QueryTimeWindowSize:  5 * time.Minute,
+		ConfidenceWindowSize: time.Millisecond,
 	}
 
 	schemaNames := make([]string, 0)

--- a/progress.go
+++ b/progress.go
@@ -236,6 +236,7 @@ func (tbpm *TableBackedProgressManager) SaveProgress(ctx context.Context, gen ti
 	tbpm.concurrentQueryLimiter.Acquire(ctx, 1)
 	defer tbpm.concurrentQueryLimiter.Release(1)
 
+	//log.Printf("SaveProgress for %s = %s\n", streamID, progress.LastProcessedRecordTime)
 	return tbpm.session.Query(
 		fmt.Sprintf("INSERT INTO %s (generation, application_name, table_name, stream_id, last_timestamp) VALUES (?, ?, ?, ?, ?) USING TTL ?", tbpm.progressTableName),
 		gen, tbpm.applicationName, tableName, streamID, progress.LastProcessedRecordTime, tbpm.ttl,

--- a/types_test.go
+++ b/types_test.go
@@ -315,12 +315,11 @@ func TestTypes(t *testing.T) {
 	})
 
 	adv := AdvancedReaderConfig{
-		ChangeAgeLimit:         time.Minute,
-		PostNonEmptyQueryDelay: 3 * time.Second,
-		PostEmptyQueryDelay:    3 * time.Second,
-		PostFailedQueryDelay:   3 * time.Second,
-		QueryTimeWindowSize:    5 * time.Minute,
-		ConfidenceWindowSize:   time.Millisecond,
+		ChangeAgeLimit:       time.Minute,
+		PostQueryDelay:       3 * time.Second,
+		PostFailedQueryDelay: 3 * time.Second,
+		QueryTimeWindowSize:  5 * time.Minute,
+		ConfidenceWindowSize: time.Millisecond,
 	}
 
 	// Configure a session

--- a/utils.go
+++ b/utils.go
@@ -71,6 +71,7 @@ func (ppr *PeriodicProgressReporter) Start(ctx context.Context) {
 				ppr.mu.Unlock()
 
 				// TODO: Log errors?
+				//ppr.logger.Printf("MarkProgress for %s: %s", ppr.reporter.streamID, timeToReport.Time())
 				err := ppr.reporter.MarkProgress(ctx, Progress{timeToReport})
 				if err != nil {
 					ppr.logger.Printf("failed to save progress for %s: %s", ppr.reporter.streamID, err)


### PR DESCRIPTION
Hi, I've been playing, testing and debugging with this lib + simple-printer example, also making use of TableBackedProgressManager + NewPeriodicProgressReporter in particular.

For some unexpected behaviour I came up with improvements/fixes I wanted to share and maybe discuss.
I've added my current findings + a new example into this PR.

#### Changes included

- adds method Empty(..) to ChangeConsumer
  (allows for marking CDC log stream time as processed, fixes 'bug' where second start of a reader begins reading CDC log on generated_created timestamp instead of ChangeAgeLimit / actual latest processed state)
- Simplify AdvancedReaderConfig options [PostEmptyQueryDelay, PostFailedQueryDelay] -> single 'PostQueryDelay' which is also considered when calculating next PollWindow
- adds new example 'simple-printer-stateful' which correctly maintains the CDC reader's state using TableBackedProgressManager + NewPeriodicProgressReporter
- adds some commented out 'logging' lines for debugging purposes

#### Options for further improvements:

- [ ] gracefully shutdown the reader+consumers allowing to mark/save current progress before exit (~call `consumer.End()` / `reporter.SaveAndStop(ctx context.Context)`)

Any questions, please reach out!