### PR TITLE
Improve the progress saving feature

### DIFF
--- a/change.go
+++ b/change.go
@@ -463,6 +463,20 @@ type ChangeConsumer interface {
 	End() error
 }
 
+// ChangeOrEmptyNotificationConsumer is an extension to the ChangeConsumer
+// interface.
+type ChangeOrEmptyNotificationConsumer interface {
+	ChangeConsumer
+
+	// Invoked upon empty results from the CDC log associated with the stream of
+	// the ChangeConsumer. This method is called to acknowledge a query window
+	// has been executed against the stream and the CDC log is to be considered
+	// completed as of 'ackTime' param passed.
+	//
+	// If this method returns an error, the library will stop with an error.
+	Empty(ctx context.Context, ackTime gocql.UUID) error
+}
+
 // MakeChangeConsumerFactoryFromFunc can be used if your processing is very
 // simple, and don't need to keep any per-stream state or save any progress.
 // The function supplied as an argument will be shared by all consumers created

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -119,3 +119,100 @@ func TestConsumerCallsEmptyCallback(t *testing.T) {
 		}
 	}
 }
+
+func TestConsumerResumesWithTableBackedProgressReporter(t *testing.T) {
+	// Makes sure that the table backed progress consumer is able to resume correctly
+	// when StartGeneration was called, but no SaveProgress has been called
+	// so far.
+
+	// Configure a session
+	address := testutils.GetSourceClusterContactPoint()
+	keyspaceName := testutils.CreateUniqueKeyspace(t, address)
+	cluster := gocql.NewCluster(address)
+	cluster.Keyspace = keyspaceName
+	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	execQuery(t, session, "CREATE TABLE tbl (pk int PRIMARY KEY, v int) WITH cdc = {'enabled': true}")
+
+	runWithProgressReporter := func(consumerFactory ChangeConsumerFactory, endTime time.Time, adv AdvancedReaderConfig) {
+		progressManager, err := NewTableBackedProgressManager(session, "progress", "test")
+		if err != nil {
+			t.Fatalf("failed to create progress manager: %v", err)
+		}
+
+		cfg := &ReaderConfig{
+			Session:               session,
+			ChangeConsumerFactory: consumerFactory,
+			TableNames:            []string{keyspaceName + ".tbl"},
+			ProgressManager:       progressManager,
+			Advanced:              adv,
+			Logger:                log.New(os.Stderr, "", log.Ldate|log.Lmicroseconds|log.Lshortfile),
+		}
+
+		reader, err := NewReader(context.Background(), cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		errC := make(chan error)
+		go func() { errC <- reader.Run(context.Background()) }()
+
+		time.Sleep(500 * time.Millisecond)
+
+		reader.StopAt(endTime)
+		if err := <-errC; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	startTime := time.Now()
+
+	adv := AdvancedReaderConfig{
+		PostNonEmptyQueryDelay: 100 * time.Millisecond,
+		PostEmptyQueryDelay:    100 * time.Millisecond,
+		PostFailedQueryDelay:   100 * time.Millisecond,
+		QueryTimeWindowSize:    100 * time.Millisecond,
+		ConfidenceWindowSize:   time.Millisecond,
+	}
+
+	// Create and start the first consumer which will not call SaveProgress
+	// Start reading from ~now and stop after two seconds
+	// We should record that we started now but recorded no progress for
+	// any stream
+	adv.ChangeAgeLimit = -time.Millisecond
+	consumer := &recordingConsumer{mu: &sync.Mutex{}}
+	runWithProgressReporter(consumer, startTime.Add(2*time.Second), adv)
+
+	// Create and start the second consumer
+	// The progress manager should resume reading from the time
+	// when the previous run was started, not 1 minute ago
+	adv.ChangeAgeLimit = 10 * time.Second
+	consumer = &recordingConsumer{mu: &sync.Mutex{}}
+	runWithProgressReporter(consumer, startTime.Add(4*time.Second), adv)
+
+	// All timestamps should be roughly between startTime and endTime
+	// To adjust for different clock on the scylla node, allow the time
+	// to exceed one second
+	acceptableStart := startTime.Add(-time.Second)
+	acceptableEnd := startTime.Add(4 * time.Second).Add(time.Second)
+
+	timestamps := consumer.GetTimestamps()
+
+	if len(timestamps) == 0 {
+		t.Fatal("no empty event timestamps recorded")
+	}
+
+	for _, tstp := range timestamps {
+		early := !acceptableStart.Before(tstp.Time())
+		late := !tstp.Time().Before(acceptableEnd)
+		if early || late {
+			t.Errorf("timestamp of empty event %s not in expected range %s, %s",
+				tstp.Time(), acceptableStart, acceptableEnd)
+		}
+	}
+}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1,0 +1,121 @@
+package scyllacdc
+
+import (
+	"context"
+	"log"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/scylladb/scylla-cdc-go/internal/testutils"
+)
+
+type recordingConsumer struct {
+	mu              *sync.Mutex
+	emptyTimestamps []gocql.UUID
+}
+
+func (rc *recordingConsumer) CreateChangeConsumer(
+	ctx context.Context,
+	input CreateChangeConsumerInput,
+) (ChangeConsumer, error) {
+	return rc, nil
+}
+
+func (rc *recordingConsumer) Consume(ctx context.Context, change Change) error {
+	return nil
+}
+
+func (rc *recordingConsumer) End() error {
+	return nil
+}
+
+func (rc *recordingConsumer) Empty(ctx context.Context, ackTime gocql.UUID) error {
+	rc.mu.Lock()
+	rc.emptyTimestamps = append(rc.emptyTimestamps, ackTime)
+	rc.mu.Unlock()
+	return nil
+}
+
+func (rc *recordingConsumer) GetTimestamps() []gocql.UUID {
+	rc.mu.Lock()
+	ret := append([]gocql.UUID{}, rc.emptyTimestamps...)
+	rc.mu.Unlock()
+	return ret
+}
+
+func TestConsumerCallsEmptyCallback(t *testing.T) {
+	consumer := &recordingConsumer{mu: &sync.Mutex{}}
+
+	adv := AdvancedReaderConfig{
+		ChangeAgeLimit:         -time.Millisecond,
+		PostNonEmptyQueryDelay: 100 * time.Millisecond,
+		PostEmptyQueryDelay:    100 * time.Millisecond,
+		PostFailedQueryDelay:   100 * time.Millisecond,
+		QueryTimeWindowSize:    100 * time.Millisecond,
+		ConfidenceWindowSize:   time.Millisecond,
+	}
+
+	// Configure a session
+	address := testutils.GetSourceClusterContactPoint()
+	keyspaceName := testutils.CreateUniqueKeyspace(t, address)
+	cluster := gocql.NewCluster(address)
+	cluster.Keyspace = keyspaceName
+	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	execQuery(t, session, "CREATE TABLE tbl (pk int PRIMARY KEY, v int) WITH cdc = {'enabled': true}")
+
+	cfg := &ReaderConfig{
+		Session:               session,
+		ChangeConsumerFactory: consumer,
+		TableNames:            []string{keyspaceName + ".tbl"},
+		Advanced:              adv,
+		Logger:                log.New(os.Stderr, "", log.Ldate|log.Lmicroseconds|log.Lshortfile),
+	}
+
+	startTime := time.Now()
+
+	reader, err := NewReader(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errC := make(chan error)
+	go func() { errC <- reader.Run(context.Background()) }()
+
+	time.Sleep(time.Second)
+
+	endTime := startTime.Add(5 * time.Second)
+	reader.StopAt(endTime)
+	if err := <-errC; err != nil {
+		t.Fatal(err)
+	}
+
+	// All timestamps should be roughly between startTime and endTime
+	// To adjust for different clock on the scylla node, allow the time
+	// to exceed one second
+	acceptableStart := startTime.Add(-time.Second)
+	acceptableEnd := endTime.Add(time.Second)
+
+	timestamps := consumer.GetTimestamps()
+
+	if len(timestamps) == 0 {
+		t.Fatal("no empty event timestamps recorded")
+	}
+
+	for _, tstp := range timestamps {
+		early := !acceptableStart.Before(tstp.Time())
+		late := !tstp.Time().Before(acceptableEnd)
+		if early || late {
+			t.Errorf("timestamp of empty event %s not in expected range %s, %s",
+				tstp.Time(), acceptableStart, acceptableEnd)
+		}
+	}
+}

--- a/examples/replicator/main.go
+++ b/examples/replicator/main.go
@@ -468,6 +468,15 @@ func (r *DeltaReplicator) End() error {
 	return nil
 }
 
+func (r *DeltaReplicator) Empty(ctx context.Context, ackTime gocql.UUID) error {
+	log.Printf("Streams [%s]: saw no changes up to %s", r.streamID, ackTime.Time())
+	r.reporter.Update(ackTime)
+	return nil
+}
+
+// Make sure that DeltaReplicator supports the ChangeOrEmptyNotificationConsumer interface
+var _ scyllacdc.ChangeOrEmptyNotificationConsumer = (*DeltaReplicator)(nil)
+
 func (r *DeltaReplicator) processUpdate(ctx context.Context, timestamp int64, c *scyllacdc.ChangeRow) error {
 	return r.processInsertOrUpdate(ctx, timestamp, false, c)
 }

--- a/reader.go
+++ b/reader.go
@@ -180,15 +180,9 @@ func NewReader(ctx context.Context, config *ReaderConfig) (*Reader, error) {
 		return nil, err
 	}
 
-	readFrom, err := config.ProgressManager.GetCurrentGeneration(ctx)
+	readFrom, err := determineStartTimestamp(ctx, config)
 	if err != nil {
 		return nil, err
-	}
-	if readFrom.IsZero() {
-		readFrom = time.Now().Add(-config.Advanced.ChangeAgeLimit)
-		config.Logger.Printf("no saved progress found, will start reading from %v", readFrom)
-	} else {
-		config.Logger.Printf("last saved progress was at generation %v", readFrom)
 	}
 
 	genFetcher, err := newGenerationFetcher(
@@ -207,6 +201,53 @@ func NewReader(ctx context.Context, config *ReaderConfig) (*Reader, error) {
 		stoppedCh:  make(chan struct{}),
 	}
 	return reader, nil
+}
+
+func determineStartTimestamp(ctx context.Context, config *ReaderConfig) (time.Time, error) {
+	mostRecentGeneration, err := config.ProgressManager.GetCurrentGeneration(ctx)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if mostRecentGeneration.IsZero() {
+		config.Logger.Printf("no information about the last generation was found")
+	} else {
+		config.Logger.Printf("last saved progress was at generation %v", mostRecentGeneration)
+	}
+
+	var applicationStartTime time.Time
+	if withStartTime, ok := config.ProgressManager.(ProgressManagerWithStartTime); ok {
+		applicationStartTime, err = withStartTime.GetApplicationReadStartTime(ctx)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if applicationStartTime.IsZero() {
+			config.Logger.Printf("no information about the application start time was found")
+		} else {
+			config.Logger.Printf("application started reading from time point %v", mostRecentGeneration)
+		}
+	}
+
+	// Choose the maximum of those two
+	readFrom := mostRecentGeneration
+	if readFrom.Before(applicationStartTime) {
+		readFrom = applicationStartTime
+	}
+
+	// If the timestamp is still zero, calculate the start time based on ChangeAgeLimit
+	if readFrom.IsZero() {
+		config.Logger.Printf("neither last generation nor application start time is available, will use ChangeAgeLimit")
+		readFrom = time.Now().Add(-config.Advanced.ChangeAgeLimit)
+
+		// Need to save this timestamp, if the ProgressManager supports that
+		if withStartTime, ok := config.ProgressManager.(ProgressManagerWithStartTime); ok {
+			if err := withStartTime.SaveApplicationReadStartTime(ctx, readFrom); err != nil {
+				return time.Time{}, err
+			}
+		}
+	}
+
+	config.Logger.Printf("the application will start reading from %v or later (depending on per-stream saved progress)", readFrom)
+	return readFrom, nil
 }
 
 // Run runs the CDC reader. This call is blocking and returns after an error occurs, or the reader

--- a/stream_batch.go
+++ b/stream_batch.go
@@ -118,6 +118,14 @@ outer:
 				// If there were no errors, then we can safely advance
 				// all streams to the window end
 				sbr.advanceAllStreamsTo(wnd.end)
+
+				if !hadRows {
+					for _, c := range sbr.consumers {
+						if enc, ok := c.(ChangeOrEmptyNotificationConsumer); ok {
+							err = enc.Empty(ctx, wnd.end)
+						}
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR fixes two issues related to progress saving:

- Currently, the ChangeConsumer is responsible for saving the current progress. However, none of its methods are called if there are no changes happening on the stream the consumer is associated with. If the application is stopped while it is in the middle of a long period of time when no changes are appearing, it will have to restart reading from the beginning of the period. The fix to this issue was to introduce an `Empty()` method (credit to @hartmut-co-uk for the idea) which is called with the read window's end timestamp in case the query didn't return any rows. Unfortunately, the fix isn't automatic and the user of the library will have to make sure to implement the `Empty()` method.
- If the library is started without previously saved progress and then stopped before it saves any progress for a stream, after restart it will start reading the stream from the beginning of the stream's generation. This can be a big issue if the last recent topology change was long ago (days, weeks, months...). The problem affects the default TableBackedProgressManager, however the ProgressManager interface is also at blame because, in its current shape, doesn't allow to fix this issue without changing it. The fix is similar as for the previous issue - an optional extension to the interface is introduced which allows to save the timestamp of the time from when the application has originally started reading. The extension is implemented for TableBackedProgressManager, so its users will have this issue automatically fixed for them.