### PR TITLE
Fix doc.go CreateChangeConsumer example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -46,7 +46,7 @@ a ChangeConsumer and a ChangeConsumerFactory:
 		nextID int
 	}
 
-	func (f *myFactory) CreateChangeConsumer(ctx context.Context, input scyllacdc.CreateChangeConsumerInput) (ChangeConsumer, error)
+	func (f *myFactory) CreateChangeConsumer(ctx context.Context, input scyllacdc.CreateChangeConsumerInput) (scyllacdc.ChangeConsumer, error) {
 		f.nextID++
 		return &myConsumer{
 			id:        f.nextID-1,


### PR DESCRIPTION
Fixes the example code in the docs so it will not error if you copy it. It was just missing an opening bracket and the package name before `ChangeConsumer`