### PR TITLE
feat: default factory with persistence

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -1,0 +1,64 @@
+package scyllacdc
+
+import (
+	"context"
+	"time"
+)
+
+type FactoryConfig struct {
+	Logger          Logger
+	CommitInterval  time.Duration
+	Callback        func(context.Context, Change) error
+	ShutdownTimeout time.Duration
+}
+
+func NewFactory(config *FactoryConfig) *factory {
+	return &factory{
+		logger:          config.Logger,
+		commitInterval:  config.CommitInterval,
+		callback:        config.Callback,
+		shutdownTimeout: config.ShutdownTimeout,
+	}
+}
+
+type factory struct {
+	logger          Logger
+	commitInterval  time.Duration
+	callback        func(context.Context, Change) error
+	shutdownTimeout time.Duration
+}
+
+type consumer struct {
+	reporter        *PeriodicProgressReporter
+	callback        func(context.Context, Change) error
+	shutdownTimeout time.Duration
+}
+
+func (f *factory) CreateChangeConsumer(ctx context.Context, input CreateChangeConsumerInput) (ChangeConsumer, error) {
+	reporter := NewPeriodicProgressReporter(f.logger, f.commitInterval, input.ProgressReporter)
+	reporter.Start(ctx)
+	return &consumer{
+		reporter:        reporter,
+		callback:        f.callback,
+		shutdownTimeout: f.shutdownTimeout,
+	}, nil
+}
+
+func (c *consumer) Consume(ctx context.Context, change Change) error {
+	err := c.callback(ctx, change)
+	if err != nil {
+		return err
+	}
+	c.reporter.Update(change.Time)
+	return nil
+}
+
+func (c *consumer) End() error {
+	ctx, cancel := context.WithTimeout(context.TODO(), c.shutdownTimeout)
+	defer cancel()
+	err := c.reporter.SaveAndStop(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Usage

```go
package main

import (
    "context"
    "log"
    "time"
    
    "github.com/gocql/gocql"
    scyllacdc "github.com/scylladb/scylla-cdc-go"
)

func main() {
    // Create ScyllaDB cluster connection
    cluster := gocql.NewCluster("127.0.0.1")
    cluster.Keyspace = "your_keyspace"
    cluster.Consistency = gocql.LocalQuorum
    cluster.Timeout = 10 * time.Second
    cluster.ConnectTimeout = 10 * time.Second
    
    // Create session
    session, err := cluster.CreateSession()
    if err != nil {
        log.Fatal("Failed to create session:", err)
    }
    defer session.Close()
    
    // Create CDC reader with advanced configuration
    readerConfig := &scyllacdc.ReaderConfig{
        Session:               session,
        TableNames:           []string{"your_table"},
        ChangeConsumerFactory: nil, // Will be set below
        Advanced: scyllacdc.AdvancedReaderConfig{
            ChangeAgeLimit:                    30 * time.Minute,
            ConfidenceWindowSize:             10 * time.Second,
            PostNonEmptyQueryDelay:           1 * time.Second,
            PostEmptyQueryDelay:              5 * time.Second,
            PostFailedQueryDelay:             30 * time.Second,
            QueryTimeWindowSize:              60 * time.Second,
        },
    }
    
    // Create progress manager
    progressManager, err := scyllacdc.NewTableBackedProgressManager(
        session,
        "cdc_progress", // progress table name
        "my_app",       // application name
    )
    if err != nil {
        log.Fatal("Failed to create progress manager:", err)
    }
    
    // Configure your CDC consumer
    config := &scyllacdc.FactoryConfig{
        CommitInterval:    5 * time.Second,
        ShutdownTimeout:   30 * time.Second,
        Callback: func(ctx context.Context, change scyllacdc.Change) error {
            // Process your CDC change here
            log.Printf("Received change: %+v", change)
            return nil
        },
    }
    
    // Create factory and set it in reader config
    factory := scyllacdc.NewFactory(config)
    readerConfig.ChangeConsumerFactory = factory
    
    // Create and start CDC reader
    reader, err := scyllacdc.NewReader(context.Background(), readerConfig)
    if err != nil {
        log.Fatal("Failed to create CDC reader:", err)
    }
    
    // Start reading changes
    err = reader.Run(context.Background())
    if err != nil {
        log.Fatal("CDC reader failed:", err)
    }
}
```

## Features

- Automatic periodic progress reporting with table-backed persistence
- Configurable commit intervals
- Graceful shutdown with timeout

## Configuration

### CDC Config
- `CommitInterval`: How often to commit progress
- `Callback`: Your change processing function  
- `ShutdownTimeout`: Maximum time to wait during shutdown

### Summary
This PR introduces FactoryConfig and NewFactory to simplify the creation of CDC consumers, especially for beginners. It abstracts away the boilerplate setup for persistence of CDC timestamps and provides a clean interface for configuring and bootstrapping a CDC factory with graceful shutdown capabilities.

### Motivation
Currently, setting up a CDC consumer with progress persistence and proper shutdown handling requires multiple manual steps. This addition aims to:

- Reduce the complexity for new users.
- Encapsulate configuration logic in a structured way.
- Promote best practices (like progress management and graceful shutdown) by default.
    