### PR TITLE
Add exponential backoff on retry for failed queries and metadata fetches

### DIFF
--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,520 @@
+package scyllacdc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql"
+)
+
+type emptyIterator struct{}
+
+func (emptyIterator) Next() (cdcChangeBatchCols, *ChangeRow) { return cdcChangeBatchCols{}, nil }
+func (emptyIterator) Close() error                           { return nil }
+
+type noopConsumer struct{}
+
+func (noopConsumer) Consume(context.Context, Change) error { return nil }
+func (noopConsumer) End() error                            { return nil }
+
+type noopConsumerFactory struct{}
+
+func (noopConsumerFactory) CreateChangeConsumer(context.Context, CreateChangeConsumerInput) (ChangeConsumer, error) {
+	return noopConsumer{}, nil
+}
+
+// callTracker records timestamps of calls in a thread-safe manner.
+type callTracker struct {
+	mu    sync.Mutex
+	times []time.Time
+}
+
+func (ct *callTracker) record() {
+	ct.mu.Lock()
+	ct.times = append(ct.times, time.Now())
+	ct.mu.Unlock()
+}
+
+func (ct *callTracker) getTimes() []time.Time {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	cp := make([]time.Time, len(ct.times))
+	copy(cp, ct.times)
+	return cp
+}
+
+func (ct *callTracker) count() int {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	return len(ct.times)
+}
+
+func newTestStreamBatchReader(
+	baseDelay, maxDelay time.Duration,
+	queryFn func(begin, end gocql.UUID) (cdcIterator, error),
+) *streamBatchReader {
+	config := &ReaderConfig{
+		ChangeConsumerFactory: noopConsumerFactory{},
+		ProgressManager:       noProgressManager{},
+		Logger:                noLogger{},
+		Advanced: AdvancedReaderConfig{
+			PostFailedQueryDelay:    baseDelay,
+			MaxPostFailedQueryDelay: maxDelay,
+			PostEmptyQueryDelay:     baseDelay,
+			PostNonEmptyQueryDelay:  baseDelay,
+			ConfidenceWindowSize:    time.Millisecond,
+			QueryTimeWindowSize:     365 * 24 * time.Hour,
+			TableMissingRetryLimit:  30,
+		},
+	}
+
+	startFrom := time.Now().Add(-time.Hour)
+	streams := []StreamID{[]byte("0123456789abcdef")} // 16 bytes
+
+	sbr := newStreamBatchReader(
+		config,
+		startFrom,
+		streams,
+		"test_ks",
+		"test_tbl",
+		gocql.MinTimeUUID(startFrom),
+	)
+	sbr.queryRangeFunc = queryFn
+	return sbr
+}
+
+func TestStreamBatchReaderBackoffOnConsecutiveFailures(t *testing.T) {
+	tracker := &callTracker{}
+	baseDelay := 5 * time.Millisecond
+	maxDelay := 80 * time.Millisecond
+
+	sbr := newTestStreamBatchReader(baseDelay, maxDelay, func(begin, end gocql.UUID) (cdcIterator, error) {
+		tracker.record()
+		return nil, errors.New("connection refused")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err := sbr.run(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+
+	times := tracker.getTimes()
+	if len(times) < 4 {
+		t.Fatalf("expected at least 4 query attempts, got %d", len(times))
+	}
+
+	if len(times) > 50 {
+		t.Errorf("too many query attempts (%d), backoff not working", len(times))
+	}
+
+	intervals := computeIntervals(times)
+	earlyAvg := avgDuration(intervals[:3])
+	lateAvg := avgDuration(intervals[len(intervals)-3:])
+
+	if lateAvg <= earlyAvg {
+		t.Errorf("late average interval (%v) should be larger than early average (%v)", lateAvg, earlyAvg)
+	}
+
+	if lateAvg < maxDelay/4 {
+		t.Errorf("late average interval (%v) should approach max delay (%v)", lateAvg, maxDelay)
+	}
+}
+
+func TestStreamBatchReaderBackoffResetOnSuccess(t *testing.T) {
+	tracker := &callTracker{}
+	baseDelay := 5 * time.Millisecond
+	maxDelay := 160 * time.Millisecond
+
+	const failsBeforeSuccess = 5
+
+	var mu sync.Mutex
+	callCount := 0
+	queryFn := func(begin, end gocql.UUID) (cdcIterator, error) {
+		tracker.record()
+		mu.Lock()
+		n := callCount
+		callCount++
+		mu.Unlock()
+
+		if n == failsBeforeSuccess {
+			return emptyIterator{}, nil
+		}
+		return nil, errors.New("connection refused")
+	}
+
+	sbr := newTestStreamBatchReader(baseDelay, maxDelay, queryFn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := sbr.run(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+
+	times := tracker.getTimes()
+	minCalls := failsBeforeSuccess + 3
+	if len(times) < minCalls {
+		t.Fatalf("expected at least %d query attempts, got %d", minCalls, len(times))
+	}
+
+	intervals := computeIntervals(times)
+	successIdx := failsBeforeSuccess
+	if len(intervals) <= successIdx+1 {
+		t.Fatalf("need at least %d intervals, got %d", successIdx+2, len(intervals))
+	}
+
+	intervalBeforeSuccess := intervals[successIdx-1]
+	intervalAfterSuccess := intervals[successIdx]
+	intervalFirstErrorAfterReset := intervals[successIdx+1]
+
+	if intervalBeforeSuccess < baseDelay*2 {
+		t.Errorf("interval before success (%v) should show backoff (>= %v)", intervalBeforeSuccess, baseDelay*2)
+	}
+
+	if intervalAfterSuccess >= intervalBeforeSuccess {
+		t.Errorf("interval after success (%v) should be shorter than before (%v) — backoff not resetting",
+			intervalAfterSuccess, intervalBeforeSuccess)
+	}
+
+	tolerance := baseDelay * 5
+	if intervalAfterSuccess > tolerance {
+		t.Errorf("interval after success (%v) should be close to base delay (%v)", intervalAfterSuccess, baseDelay)
+	}
+	if intervalFirstErrorAfterReset > tolerance {
+		t.Errorf("first failure after reset (%v) should be close to base delay (%v)", intervalFirstErrorAfterReset, baseDelay)
+	}
+}
+
+func TestStreamBatchReaderTableMissingGivesUp(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "ErrNotFound (original table deleted)",
+			err:  fmt.Errorf("failed to get CDC table columns: %w", gocql.ErrNotFound),
+		},
+		{
+			name: "unconfigured table (CDC table deleted)",
+			err:  fmt.Errorf("unconfigured table test_ks.test_tbl_scylla_cdc_log"),
+		},
+		{
+			name: "no such table",
+			err:  fmt.Errorf("no such table test_ks.test_tbl_scylla_cdc_log"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := &callTracker{}
+
+			sbr := newTestStreamBatchReader(time.Millisecond, 5*time.Millisecond,
+				func(begin, end gocql.UUID) (cdcIterator, error) {
+					tracker.record()
+					return nil, tt.err
+				},
+			)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			err := sbr.run(ctx)
+
+			if errors.Is(err, context.DeadlineExceeded) {
+				t.Fatal("reader should have given up before context timeout")
+			}
+			if err == nil {
+				t.Fatal("expected an error from table-missing retry limit")
+			}
+			if !errors.Is(err, tt.err) {
+				t.Logf("returned error: %v", err)
+			}
+
+			count := tracker.count()
+			if count != 31 {
+				t.Errorf("expected exactly 31 attempts (30 retries + 1 final), got %d", count)
+			}
+		})
+	}
+}
+
+func TestStreamBatchReaderGenericErrorDoesNotGiveUp(t *testing.T) {
+	tracker := &callTracker{}
+
+	sbr := newTestStreamBatchReader(time.Millisecond, 5*time.Millisecond,
+		func(begin, end gocql.UUID) (cdcIterator, error) {
+			tracker.record()
+			return nil, errors.New("connection refused")
+		},
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := sbr.run(ctx)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded (reader should not give up on generic errors), got: %v", err)
+	}
+
+	count := tracker.count()
+	if count <= 31 {
+		t.Errorf("expected more than 31 attempts to prove no retry limit was hit, got %d", count)
+	}
+}
+
+func TestStreamBatchReaderTableMissingResetsOnSuccess(t *testing.T) {
+	tracker := &callTracker{}
+	var mu sync.Mutex
+	callCount := 0
+
+	// Return table-missing for 25 calls, then success, then table-missing forever.
+	// After reset, it should survive another 30 retries.
+	queryFn := func(begin, end gocql.UUID) (cdcIterator, error) {
+		tracker.record()
+		mu.Lock()
+		n := callCount
+		callCount++
+		mu.Unlock()
+
+		if n == 25 {
+			return emptyIterator{}, nil
+		}
+		return nil, gocql.ErrNotFound
+	}
+
+	sbr := newTestStreamBatchReader(time.Millisecond, 5*time.Millisecond, queryFn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := sbr.run(ctx)
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("reader should have given up before context timeout")
+	}
+	if err == nil {
+		t.Fatal("expected table-missing error")
+	}
+
+	// Total calls: 25 (table missing) + 1 (success) + 31 (table missing, gives up on 31st) = 57
+	count := tracker.count()
+	if count != 57 {
+		t.Errorf("expected 57 attempts (25 + 1 success + 31), got %d", count)
+	}
+}
+
+type mockGenerationSource struct {
+	mu         sync.Mutex
+	getTimesFn func(gocql.Consistency) ([]time.Time, error)
+}
+
+func (m *mockGenerationSource) getGenerationTimes(consistency gocql.Consistency) ([]time.Time, error) {
+	m.mu.Lock()
+	fn := m.getTimesFn
+	m.mu.Unlock()
+	return fn(consistency)
+}
+
+func (m *mockGenerationSource) getGeneration(genTime time.Time, consistency gocql.Consistency) ([][]StreamID, error) {
+	return nil, nil
+}
+
+func (m *mockGenerationSource) maybeUpgrade() (generationSource, error) {
+	return m, nil
+}
+
+func newTestGenerationFetcher(
+	basePeriod, maxPeriod time.Duration,
+	source generationSource,
+) *generationFetcher {
+	return &generationFetcher{
+		logger:   noLogger{},
+		lastTime: time.Now().Add(-time.Hour),
+		source:   source,
+
+		generationCh: make(chan *generation, 1),
+		stopCh:       make(chan struct{}),
+		refreshCh:    make(chan struct{}, 1),
+
+		fetchPeriod:    basePeriod,
+		maxFetchPeriod: maxPeriod,
+
+		clusterSizeFunc: func() (int, error) { return 3, nil },
+	}
+}
+
+func TestGenerationFetcherBackoffOnConsecutiveFailures(t *testing.T) {
+	tracker := &callTracker{}
+	basePeriod := 5 * time.Millisecond
+	maxPeriod := 80 * time.Millisecond
+
+	source := &mockGenerationSource{
+		getTimesFn: func(gocql.Consistency) ([]time.Time, error) {
+			tracker.record()
+			return nil, errors.New("connection refused")
+		},
+	}
+
+	gf := newTestGenerationFetcher(basePeriod, maxPeriod, source)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	_ = gf.Run(ctx)
+
+	times := tracker.getTimes()
+	if len(times) < 4 {
+		t.Fatalf("expected at least 4 fetch attempts, got %d", len(times))
+	}
+
+	if len(times) > 50 {
+		t.Errorf("too many fetch attempts (%d), backoff not working", len(times))
+	}
+
+	intervals := computeIntervals(times)
+	earlyAvg := avgDuration(intervals[:3])
+	lateAvg := avgDuration(intervals[len(intervals)-3:])
+
+	if lateAvg <= earlyAvg {
+		t.Errorf("late average interval (%v) should be larger than early average (%v)", lateAvg, earlyAvg)
+	}
+
+	if lateAvg < maxPeriod/4 {
+		t.Errorf("late average interval (%v) should approach max period (%v)", lateAvg, maxPeriod)
+	}
+}
+
+func TestGenerationFetcherBackoffResetOnSuccess(t *testing.T) {
+	tracker := &callTracker{}
+	basePeriod := 5 * time.Millisecond
+	maxPeriod := 160 * time.Millisecond
+
+	const failsBeforeSuccess = 5
+
+	var mu sync.Mutex
+	callCount := 0
+
+	source := &mockGenerationSource{
+		getTimesFn: func(gocql.Consistency) ([]time.Time, error) {
+			tracker.record()
+			mu.Lock()
+			n := callCount
+			callCount++
+			mu.Unlock()
+
+			if n == failsBeforeSuccess {
+				return nil, nil
+			}
+			return nil, errors.New("connection refused")
+		},
+	}
+
+	gf := newTestGenerationFetcher(basePeriod, maxPeriod, source)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_ = gf.Run(ctx)
+
+	times := tracker.getTimes()
+	minCalls := failsBeforeSuccess + 3
+	if len(times) < minCalls {
+		t.Fatalf("expected at least %d fetch attempts, got %d", minCalls, len(times))
+	}
+
+	intervals := computeIntervals(times)
+	successIdx := failsBeforeSuccess
+	if len(intervals) <= successIdx+1 {
+		t.Fatalf("need at least %d intervals, got %d", successIdx+2, len(intervals))
+	}
+
+	intervalBeforeSuccess := intervals[successIdx-1]
+	intervalAfterSuccess := intervals[successIdx]
+	intervalFirstErrorAfterReset := intervals[successIdx+1]
+
+	if intervalBeforeSuccess < basePeriod*2 {
+		t.Errorf("interval before success (%v) should show backoff (>= %v)", intervalBeforeSuccess, basePeriod*2)
+	}
+
+	if intervalAfterSuccess >= intervalBeforeSuccess {
+		t.Errorf("interval after success (%v) should be shorter than before (%v) — backoff not resetting",
+			intervalAfterSuccess, intervalBeforeSuccess)
+	}
+
+	tolerance := basePeriod * 5
+	if intervalAfterSuccess > tolerance {
+		t.Errorf("interval after success (%v) should be close to base period (%v)", intervalAfterSuccess, basePeriod)
+	}
+	if intervalFirstErrorAfterReset > tolerance {
+		t.Errorf("first failure after reset (%v) should be close to base period (%v)", intervalFirstErrorAfterReset, basePeriod)
+	}
+}
+
+func TestGenerationFetcherClusterSizeErrorBackoff(t *testing.T) {
+	tracker := &callTracker{}
+	basePeriod := 5 * time.Millisecond
+	maxPeriod := 80 * time.Millisecond
+
+	source := &mockGenerationSource{
+		getTimesFn: func(gocql.Consistency) ([]time.Time, error) {
+			// Should not be called because getClusterSize fails first
+			t.Error("getGenerationTimes should not be called when getClusterSize fails")
+			return nil, nil
+		},
+	}
+
+	gf := newTestGenerationFetcher(basePeriod, maxPeriod, source)
+	gf.clusterSizeFunc = func() (int, error) {
+		tracker.record()
+		return 0, errors.New("cannot reach cluster")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	_ = gf.Run(ctx)
+
+	times := tracker.getTimes()
+	if len(times) < 4 {
+		t.Fatalf("expected at least 4 attempts, got %d", len(times))
+	}
+
+	if len(times) > 50 {
+		t.Errorf("too many attempts (%d), backoff not working for cluster size errors", len(times))
+	}
+
+	intervals := computeIntervals(times)
+	earlyAvg := avgDuration(intervals[:2])
+	lateAvg := avgDuration(intervals[len(intervals)-2:])
+	if lateAvg <= earlyAvg {
+		t.Errorf("late average interval (%v) should be larger than early average (%v)", lateAvg, earlyAvg)
+	}
+}
+
+func computeIntervals(times []time.Time) []time.Duration {
+	intervals := make([]time.Duration, 0, len(times)-1)
+	for i := 1; i < len(times); i++ {
+		intervals = append(intervals, times[i].Sub(times[i-1]))
+	}
+	return intervals
+}
+
+func avgDuration(ds []time.Duration) time.Duration {
+	if len(ds) == 0 {
+		return 0
+	}
+	var sum time.Duration
+	for _, d := range ds {
+		sum += d
+	}
+	return sum / time.Duration(len(ds))
+}

--- a/reader.go
+++ b/reader.go
@@ -104,11 +104,21 @@ type AdvancedReaderConfig struct {
 
 	// If the library tries to read from the CDC log and the read operation
 	// fails, it will wait some time before attempting to read again. This
-	// parameter specifies the length of the delay.
+	// parameter specifies the initial length of the delay. On consecutive
+	// failures, the delay increases exponentially up to MaxPostFailedQueryDelay.
 	//
 	// If the parameter is left as 0, the library will automatically adjust
 	// the length of the delay.
 	PostFailedQueryDelay time.Duration
+
+	// MaxPostFailedQueryDelay defines the upper bound for the exponential
+	// backoff delay after consecutive failed queries. The delay starts at
+	// PostFailedQueryDelay and doubles on each consecutive failure, up to
+	// this maximum.
+	//
+	// If the parameter is left as 0, the library will automatically choose
+	// a default maximum delay.
+	MaxPostFailedQueryDelay time.Duration
 
 	// Changes are queried using select statements with restriction on the time
 	// those changes appeared. The restriction is bounding the time from both
@@ -133,6 +143,21 @@ type AdvancedReaderConfig struct {
 	// the size of the restriction window.
 	ChangeAgeLimit time.Duration
 
+	// PostGenerationFetchDelay defines the base polling interval for
+	// fetching new CDC generations from the cluster. On consecutive
+	// failures, this interval increases exponentially up to
+	// MaxPostGenerationFetchDelay.
+	//
+	// If the parameter is left as 0, the default value of 15 seconds is used.
+	PostGenerationFetchDelay time.Duration
+
+	// MaxPostGenerationFetchDelay defines the upper bound for the
+	// exponential backoff when polling for new CDC generations fails
+	// consecutively.
+	//
+	// If the parameter is left as 0, the default value of 5 minutes is used.
+	MaxPostGenerationFetchDelay time.Duration
+
 	// TableMissingRetryLimit defines the maximum number of consecutive
 	// poll iterations that can fail with a "table missing" error before
 	// the reader gives up and returns an error. This is useful during
@@ -155,9 +180,13 @@ func (arc *AdvancedReaderConfig) setDefaults() {
 	setIfZero(&arc.PostNonEmptyQueryDelay, 10*time.Second)
 	setIfZero(&arc.PostEmptyQueryDelay, 30*time.Second)
 	setIfZero(&arc.PostFailedQueryDelay, 1*time.Second)
+	setIfZero(&arc.MaxPostFailedQueryDelay, 30*time.Second)
 
 	setIfZero(&arc.QueryTimeWindowSize, 30*time.Second)
 	setIfZero(&arc.ChangeAgeLimit, 1*time.Minute)
+
+	setIfZero(&arc.PostGenerationFetchDelay, 15*time.Second)
+	setIfZero(&arc.MaxPostGenerationFetchDelay, 5*time.Minute)
 
 	if arc.TableMissingRetryLimit == 0 {
 		arc.TableMissingRetryLimit = 30
@@ -203,6 +232,8 @@ func NewReader(ctx context.Context, config *ReaderConfig) (*Reader, error) {
 		readFrom,
 		config.Logger,
 		config.TableNames,
+		config.Advanced.PostGenerationFetchDelay,
+		config.Advanced.MaxPostGenerationFetchDelay,
 	)
 	if err != nil {
 		return nil, err

--- a/stream_batch.go
+++ b/stream_batch.go
@@ -11,6 +11,12 @@ import (
 	"github.com/gocql/gocql"
 )
 
+// cdcIterator abstracts iteration over CDC log query results.
+type cdcIterator interface {
+	Next() (cdcChangeBatchCols, *ChangeRow)
+	Close() error
+}
+
 type streamBatchReader struct {
 	config         *ReaderConfig
 	generationTime time.Time
@@ -26,6 +32,11 @@ type streamBatchReader struct {
 	perStreamProgress map[string]gocql.UUID
 
 	interruptCh chan struct{}
+
+	consecutiveQueryFailures int
+
+	// queryRangeFunc overrides the default query mechanism. Used for testing.
+	queryRangeFunc func(begin, end gocql.UUID) (cdcIterator, error)
 }
 
 func newStreamBatchReader(
@@ -90,7 +101,13 @@ func (sbr *streamBatchReader) run(ctx context.Context) (err error) {
 		sbr.consumers[string(s)] = consumer
 	}
 
-	crq := newChangeRowQuerier(sbr.config.Session, sbr.streams, sbr.keyspaceName, sbr.tableName, sbr.config.Consistency)
+	queryRange := sbr.queryRangeFunc
+	if queryRange == nil {
+		crq := newChangeRowQuerier(sbr.config.Session, sbr.streams, sbr.keyspaceName, sbr.tableName, sbr.config.Consistency)
+		queryRange = func(begin, end gocql.UUID) (cdcIterator, error) {
+			return crq.queryRange(begin, end)
+		}
+	}
 
 	wnd := sbr.getPollWindow()
 
@@ -105,8 +122,8 @@ outer:
 		windowProcessingStartTime := time.Now()
 
 		if CompareTimeUUID(wnd.begin, wnd.end) < 0 {
-			var iter *changeRowIterator
-			iter, err = crq.queryRange(wnd.begin, wnd.end)
+			var iter cdcIterator
+			iter, err = queryRange(wnd.begin, wnd.end)
 			if err != nil {
 				if isTableMissingError(err) {
 					tableMissingRetries++
@@ -149,10 +166,17 @@ outer:
 		var delay time.Duration
 		switch {
 		case err != nil:
-			delay = sbr.config.Advanced.PostFailedQueryDelay
+			sbr.consecutiveQueryFailures++
+			delay = addJitter(backoffDelay(
+				sbr.config.Advanced.PostFailedQueryDelay,
+				sbr.config.Advanced.MaxPostFailedQueryDelay,
+				sbr.consecutiveQueryFailures,
+			))
 		case hadRows:
+			sbr.consecutiveQueryFailures = 0
 			delay = sbr.config.Advanced.PostNonEmptyQueryDelay
 		default:
+			sbr.consecutiveQueryFailures = 0
 			delay = sbr.config.Advanced.PostEmptyQueryDelay
 		}
 
@@ -256,7 +280,7 @@ func (sbr *streamBatchReader) getConfidenceLimitPoint() time.Time {
 	return time.Now().Add(-sbr.config.Advanced.ConfidenceWindowSize)
 }
 
-func (sbr *streamBatchReader) processRows(ctx context.Context, iter *changeRowIterator) (int, error) {
+func (sbr *streamBatchReader) processRows(ctx context.Context, iter cdcIterator) (int, error) {
 	rowCount := 0
 	var change Change
 

--- a/topology.go
+++ b/topology.go
@@ -29,11 +29,6 @@ const (
 
 	getGenerationTimesQueryForTablets = "SELECT timestamp FROM " + timestampsTableForTablets + " WHERE keyspace_name = ? AND table_name = ?"
 	getGenerationQueryForTablets      = "SELECT stream_id FROM " + streamsTableForTablets + " WHERE keyspace_name = ? AND table_name = ? AND timestamp = ? AND stream_state = ?"
-
-	// TODO: Switch to a model which reacts to cluster state changes
-	// and forces a refresh when all worker goroutines did not report any
-	// changes for some time
-	generationFetchPeriod time.Duration = 15 * time.Second
 )
 
 // follows the stream_state column in system.cdc_streams
@@ -82,6 +77,13 @@ type generationFetcher struct {
 	stopCh       chan struct{}
 
 	source generationSource
+
+	consecutiveFetchFailures int
+
+	fetchPeriod    time.Duration
+	maxFetchPeriod time.Duration
+
+	clusterSizeFunc func() (int, error)
 }
 
 func newGenerationFetcher(
@@ -89,6 +91,8 @@ func newGenerationFetcher(
 	startFrom time.Time,
 	logger Logger,
 	tableNames []string,
+	fetchPeriod time.Duration,
+	maxFetchPeriod time.Duration,
 ) (*generationFetcher, error) {
 	source, err := chooseGenerationSource(session, logger, tableNames)
 	if err != nil {
@@ -105,6 +109,18 @@ func newGenerationFetcher(
 		refreshCh:    make(chan struct{}, 1),
 
 		source: source,
+
+		fetchPeriod:    fetchPeriod,
+		maxFetchPeriod: maxFetchPeriod,
+
+		clusterSizeFunc: func() (int, error) {
+			var size int
+			err := session.Query("SELECT COUNT(*) FROM system.peers").Scan(&size)
+			if err != nil {
+				return 0, err
+			}
+			return size + 1, nil
+		},
 	}
 	return gf, nil
 }
@@ -179,11 +195,17 @@ func (gf *generationFetcher) Run(ctx context.Context) error {
 
 outer:
 	for {
-		// Generation processing can take some time, so start calculating
-		// the next poll time starting from now
-		waitC := time.After(generationFetchPeriod)
+		failed := gf.tryFetchGenerations()
 
-		gf.tryFetchGenerations()
+		var waitDuration time.Duration
+		if failed {
+			gf.consecutiveFetchFailures++
+			waitDuration = addJitter(backoffDelay(gf.fetchPeriod, gf.maxFetchPeriod, gf.consecutiveFetchFailures))
+		} else {
+			gf.consecutiveFetchFailures = 0
+			waitDuration = gf.fetchPeriod
+		}
+		waitC := time.After(waitDuration)
 
 		select {
 		// Give priority to the stop channel and the context
@@ -208,12 +230,12 @@ outer:
 	return nil
 }
 
-func (gf *generationFetcher) tryFetchGenerations() {
+func (gf *generationFetcher) tryFetchGenerations() (failed bool) {
 	// Decide on the consistency to use
 	size, err := gf.getClusterSize()
 	if err != nil {
 		gf.logger.Printf("an error occurred while determining cluster size: %s", err)
-		return
+		return true
 	}
 
 	consistency := gocql.One
@@ -233,7 +255,7 @@ func (gf *generationFetcher) tryFetchGenerations() {
 	times, err := gf.source.getGenerationTimes(consistency)
 	if err != nil {
 		gf.logger.Printf("an error occurred while fetching generation times: %s", err)
-		return
+		return true
 	}
 	sort.Sort(timeList(times))
 
@@ -241,6 +263,7 @@ func (gf *generationFetcher) tryFetchGenerations() {
 		streams, err := gf.source.getGeneration(t, consistency)
 		if err != nil {
 			gf.logger.Printf("an error occurred while fetching generation streams for %s: %s", t, err)
+			failed = true
 			return true
 		}
 		gen := &generation{t, streams}
@@ -276,11 +299,11 @@ func (gf *generationFetcher) tryFetchGenerations() {
 		if gf.lastTime.Before(t) {
 
 			if shouldBreak := maybePushFirst(); shouldBreak {
-				return
+				return failed
 			}
 
 			if shouldBreak := fetchAndPush(t); shouldBreak {
-				return
+				return failed
 			}
 			gf.lastTime = t
 		}
@@ -288,6 +311,7 @@ func (gf *generationFetcher) tryFetchGenerations() {
 	}
 
 	_ = maybePushFirst()
+	return failed
 }
 
 func (gf *generationFetcher) Get(ctx context.Context) (*generation, error) {
@@ -321,15 +345,8 @@ func (gf *generationFetcher) pushGeneration(gen *generation) (shouldStop bool) {
 	}
 }
 
-// Unfortunately, gocql does not expose information about the cluster,
-// therefore we need to poll system.peers manually
 func (gf *generationFetcher) getClusterSize() (int, error) {
-	var size int
-	err := gf.session.Query("SELECT COUNT(*) FROM system.peers").Scan(&size)
-	if err != nil {
-		return 0, err
-	}
-	return size + 1, nil
+	return gf.clusterSizeFunc()
 }
 
 type generationSource interface {

--- a/utils.go
+++ b/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"regexp"
 	"strconv"
 	"strings"
@@ -126,6 +127,33 @@ func (ppr *PeriodicProgressReporter) SaveAndStop(ctx context.Context) error {
 		ppr.logger.Printf("successfully saved final progress for %s: %s (%s)", ppr.reporter.streamID, ppr.timeToReport, ppr.timeToReport.Time())
 	}
 	return err
+}
+
+// backoffDelay computes an exponential backoff delay given a base delay,
+// a maximum delay, and the number of consecutive failures (starting from 1).
+// The delay doubles on each consecutive failure, capped at maxDelay.
+func backoffDelay(baseDelay, maxDelay time.Duration, consecutiveFailures int) time.Duration {
+	delay := baseDelay
+	for i := 1; i < consecutiveFailures; i++ {
+		if delay >= maxDelay/2 {
+			return maxDelay
+		}
+		delay *= 2
+	}
+	if delay > maxDelay {
+		return maxDelay
+	}
+	return delay
+}
+
+// addJitter applies random jitter to a duration, returning a value
+// uniformly distributed in [d/2, 3d/2].
+func addJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	half := d / 2
+	return half + time.Duration(rand.Int64N(int64(d)))
 }
 
 func CompareTimeUUID(u1, u2 gocql.UUID) int {

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,6 +2,7 @@ package scyllacdc
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gocql/gocql"
 )
@@ -38,5 +39,64 @@ func TestTimeUUIDCompare(t *testing.T) {
 				t.Errorf("expected %s to be larger than %s", u1, u2)
 			}
 		}
+	}
+}
+
+func TestBackoffDelay(t *testing.T) {
+	base := 1 * time.Second
+	maxDelay := 30 * time.Second
+
+	tests := []struct {
+		failures int
+		expected time.Duration
+	}{
+		{1, 1 * time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{4, 8 * time.Second},
+		{5, 16 * time.Second},
+		{6, 30 * time.Second}, // capped
+		{7, 30 * time.Second}, // stays capped
+		{100, 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		got := backoffDelay(base, maxDelay, tt.failures)
+		if got != tt.expected {
+			t.Errorf("backoffDelay(%v, %v, %d) = %v, want %v", base, maxDelay, tt.failures, got, tt.expected)
+		}
+	}
+}
+
+func TestBackoffDelayNoOverflow(t *testing.T) {
+	base := time.Hour
+	maxDelay := 24 * time.Hour
+
+	got := backoffDelay(base, maxDelay, 1000)
+	if got != maxDelay {
+		t.Errorf("backoffDelay with extreme failures = %v, want %v (should cap, not overflow)", got, maxDelay)
+	}
+	if got < 0 {
+		t.Errorf("backoffDelay overflowed to negative: %v", got)
+	}
+}
+
+func TestAddJitter(t *testing.T) {
+	d := 100 * time.Millisecond
+	lo := d / 2
+	hi := d/2 + d
+
+	for range 1000 {
+		jittered := addJitter(d)
+		if jittered < lo || jittered > hi {
+			t.Errorf("addJitter(%v) = %v, want in [%v, %v]", d, jittered, lo, hi)
+		}
+	}
+
+	if got := addJitter(0); got != 0 {
+		t.Errorf("addJitter(0) = %v, want 0", got)
+	}
+	if got := addJitter(-time.Second); got != -time.Second {
+		t.Errorf("addJitter(-1s) = %v, want -1s", got)
 	}
 }


### PR DESCRIPTION
## Summary

- The stream batch reader and generation fetcher previously used **constant delays** when retrying after failures, which could overwhelm a struggling cluster
- Both now use **exponential backoff** on consecutive failures, resetting on success
- Adds `MaxPostFailedQueryDelay` config field (default 30s) as the upper bound for CDC log query retries
- Generation fetcher backs off from 15s up to 5min on consecutive metadata fetch failures
- Adds `backoffDelay` helper with unit tests

Closes #50

## Test plan

- [x] Unit test for `backoffDelay` helper passes
- [x] Project compiles cleanly
- [x] Integration test with a cluster experiencing transient failures to verify backoff behavior
